### PR TITLE
When plotting pairs statistics for forecasts within a pool that conta…

### DIFF
--- a/src/wres/pipeline/StatisticsConsumerFactory.java
+++ b/src/wres/pipeline/StatisticsConsumerFactory.java
@@ -138,7 +138,9 @@ class StatisticsConsumerFactory implements ConsumerFactory
             // Specific formats are filtered at runtime via the router using the Outputs declaration
             BoxplotGraphicsWriter boxPlotWriter = BoxplotGraphicsWriter.of( outputs, path );
             builder.addBoxplotConsumerPerPair( wres.config.yaml.components.Format.GRAPHIC,
-                                               boxPlotWriter );
+                                               boxPlotWriter )
+                   .addPairsStatisticsConsumer( wres.config.yaml.components.Format.GRAPHIC,
+                                                PairsStatisticsGraphicsWriter.of( outputs, path ) );
         }
 
         // Old-style CSV
@@ -227,9 +229,7 @@ class StatisticsConsumerFactory implements ConsumerFactory
                    .addDiagramConsumer( wres.config.yaml.components.Format.GRAPHIC,
                                         DiagramGraphicsWriter.of( outputs, path ) )
                    .addDurationDiagramConsumer( wres.config.yaml.components.Format.GRAPHIC,
-                                                DurationDiagramGraphicsWriter.of( outputs, path ) )
-                   .addPairsStatisticsConsumer( wres.config.yaml.components.Format.GRAPHIC,
-                                                PairsStatisticsGraphicsWriter.of( outputs, path ) );
+                                                DurationDiagramGraphicsWriter.of( outputs, path ) );
         }
 
         // Note that diagrams are always written by group, even if all the statistics could be written per pool because

--- a/wres-vis/src/wres/vis/charts/ChartFactory.java
+++ b/wres-vis/src/wres/vis/charts/ChartFactory.java
@@ -478,7 +478,7 @@ public class ChartFactory
                 this.setChartTheme( chart );
 
                 // Set the series renderer
-                XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty() );
+                XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty(), true );
                 plot.setRenderer( renderer );
 
                 // Set the axis offsets to zero. Could abstract to setting chart theme above, but breaks test benchmarks
@@ -523,7 +523,7 @@ public class ChartFactory
                 this.setChartTheme( chart );
 
                 // Set the series renderer
-                XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty() );
+                XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty(), true );
                 plot.setRenderer( renderer );
             }
 
@@ -656,7 +656,7 @@ public class ChartFactory
         this.setChartPadding( chart );
 
         // Set the series renderer
-        XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty() );
+        XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty(), true );
         plot.setRenderer( renderer );
 
         // Set the legend on/off and the title
@@ -876,6 +876,13 @@ public class ChartFactory
         // Build the dataset
         XYDataset source = ChartDataFactory.ofPairsStatistics( statistics );
 
+        int seriesCount = source.getSeriesCount();
+        int maxPairs = 0;
+        for ( int i = 0; i < seriesCount; i++ )
+        {
+            maxPairs = Math.max( source.getItemCount( i ), maxPairs );
+        }
+
         TimeWindowOuter timeWindow = metadata.getTimeWindow();
         ChartTitleParameters parameters = new ChartTitleParameters( Set.of( metadata ),
                                                                     timeWindow,
@@ -927,7 +934,10 @@ public class ChartFactory
         this.setChartPadding( chart );
 
         // Set the series renderer
-        XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, false );
+        XYItemRenderer renderer = this.getSeriesColorAndShape( plot,
+                                                               metricName,
+                                                               false,
+                                                               maxPairs <= 1 );
         plot.setRenderer( renderer );
 
         // To quote the documentation, this setting "usually" improve the appearance of charts. However, experimentation
@@ -1262,7 +1272,10 @@ public class ChartFactory
         XYPlot plot = chart.getXYPlot();
 
         // Set the series renderer
-        XYItemRenderer renderer = this.getSeriesColorAndShape( plot, metricName, !quantiles.isEmpty() );
+        XYItemRenderer renderer = this.getSeriesColorAndShape( plot,
+                                                               metricName,
+                                                               !quantiles.isEmpty(),
+                                                               true );
         plot.setRenderer( renderer );
 
         // Set the legend on/off and the title
@@ -1342,7 +1355,8 @@ public class ChartFactory
         // Set the series renderer
         XYItemRenderer renderer = this.getSeriesColorAndShape( reliabilityPlot,
                                                                MetricConstants.RELIABILITY_DIAGRAM,
-                                                               !quantiles.isEmpty() );
+                                                               !quantiles.isEmpty(),
+                                                               true );
         reliabilityPlot.setRenderer( renderer );
 
         XYPlot sampleSizePlot = new XYPlot( sampleSize, domainAxis, secondaryRangeAxis, null );
@@ -1355,7 +1369,8 @@ public class ChartFactory
         // Set the series renderer
         XYItemRenderer sampleRenderer = this.getSeriesColorAndShape( sampleSizePlot,
                                                                      MetricConstants.RELIABILITY_DIAGRAM,
-                                                                     !quantiles.isEmpty() );
+                                                                     !quantiles.isEmpty(),
+                                                                     true );
         sampleSizePlot.setRenderer( sampleRenderer );
 
         CombinedDomainXYPlot combinedPlot = new CombinedDomainXYPlot( domainAxis );
@@ -1601,11 +1616,15 @@ public class ChartFactory
      * @param plot the plot
      * @param metric the metric name
      * @param errorBars is true to plot error bars, false otherwise
+     * @param showShapes is true to show shapes in a line and shape renderer, false for lines only
      * @return the renderer
      * @throws NullPointerException if the plot is null
      */
 
-    private XYItemRenderer getSeriesColorAndShape( XYPlot plot, MetricConstants metric, boolean errorBars )
+    private XYItemRenderer getSeriesColorAndShape( XYPlot plot,
+                                                   MetricConstants metric,
+                                                   boolean errorBars,
+                                                   boolean showShapes )
     {
         XYItemRenderer renderer;
         if ( metric == MetricConstants.HISTOGRAM )
@@ -1620,7 +1639,7 @@ public class ChartFactory
             renderer = this.getLineAndShapeRenderer( plot,
                                                      errorBars,
                                                      false,
-                                                     true,
+                                                     showShapes,
                                                      false,
                                                      false,
                                                      new Shape[] { shape } );
@@ -1631,7 +1650,7 @@ public class ChartFactory
             renderer = this.getLineAndShapeRenderer( plot,
                                                      errorBars,
                                                      true,
-                                                     false,
+                                                     showShapes,
                                                      false,
                                                      metric == MetricConstants.SPAGHETTI_PLOT,
                                                      DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE );
@@ -1641,7 +1660,7 @@ public class ChartFactory
             renderer = this.getLineAndShapeRenderer( plot,
                                                      errorBars,
                                                      true,
-                                                     true,
+                                                     showShapes,
                                                      true,
                                                      false,
                                                      DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE );
@@ -1734,7 +1753,7 @@ public class ChartFactory
                     renderer.setSeriesPaint( rightIndex, color );
                     renderer.setSeriesShape( rightIndex, shape );
                     renderer.setSeriesShapesVisible( rightIndex, showShapes );
-                    renderer.setSeriesShapesFilled( rightIndex, false );
+                    renderer.setSeriesShapesFilled( rightIndex, true );
                     renderer.setSeriesLinesVisible( rightIndex, showLines );
                     renderer.setSeriesVisibleInLegend( rightIndex, false );
 

--- a/wres-vis/src/wres/vis/client/GraphicsConsumerFactory.java
+++ b/wres-vis/src/wres/vis/client/GraphicsConsumerFactory.java
@@ -64,6 +64,8 @@ class GraphicsConsumerFactory implements ConsumerFactory
                 = builder.setEvaluationDescription( evaluation )
                          .addBoxplotConsumerPerPair( wres.config.yaml.components.Format.GRAPHIC,
                                                      BoxplotGraphicsWriter.of( outputs, path ) )
+                         .addPairsStatisticsConsumer( wres.config.yaml.components.Format.GRAPHIC,
+                                                      PairsStatisticsGraphicsWriter.of( outputs, path ) )
                          .build();
 
 
@@ -104,8 +106,6 @@ class GraphicsConsumerFactory implements ConsumerFactory
                                              DiagramGraphicsWriter.of( outputs, path ) )
                         .addDurationDiagramConsumer( wres.config.yaml.components.Format.GRAPHIC,
                                                      DurationDiagramGraphicsWriter.of( outputs, path ) )
-                        .addPairsStatisticsConsumer( wres.config.yaml.components.Format.GRAPHIC,
-                                                     PairsStatisticsGraphicsWriter.of( outputs, path ) )
                         .build();
 
         return StatisticsConsumer.getResourceFreeConsumer( router );


### PR DESCRIPTION
…ins a single lead duration, set the series shapes visible. Also, consume pairs statistics per pool rather than all pools in a group #177.

## Description
Plot pairs statistics for a forecast time-series with a single point using filled shapes.

### Changes Made
- 

### Testing
- 

### Related Tickets
- Fixes #177.

## Checklists
### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [ ] Feature addition
- [ ] Bug fix
- [ ] Database change


### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [ ] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [ ] Links are provided if this PR resolves an issue, or depends on another other PR
- [ ] The feature branch you're submitting as a PR is up to date
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] No Placeholder code
- [ ] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
- [ ] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR

### Merge Checklist (For Technical Lead use only)

- [ ] If applicable, update [README](/README.md) with major alterations
