### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![commitChecks](https://github.com/NOAA-OWP/wres/actions/workflows/commitChecks.yml/badge.svg)
+![commitChecks](https://github.com/NOAA-OWP/wres/actions/workflows/commitChecks.yml/badge.svg) [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NOAA-OWP/wres)
 
 # Water Resources Evaluation Service (WRES)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NOAA-OWP/wres) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.